### PR TITLE
Replace "xcb" with "as-raw-xcb-connection"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,10 @@ bitflags = "1"
 libc     = "0.2"
 ffi      = { package = "xkbcommon-sys", version = "1.4.1" }
 
-[dependencies.xcb]
+[dependencies.as-raw-xcb-connection]
 version  = "1"
-features = ["xkb"]
 optional = true
 
 [features]
 static = ["ffi/static"]
-x11    = ["ffi/x11", "xcb"]
+x11    = ["ffi/x11", "as-raw-xcb-connection"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![allow(non_upper_case_globals)]
 
-#[cfg(feature = "x11")]
-extern crate xcb;
-
 #[macro_use]
 mod base;
 pub use self::base::*;

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -12,7 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use xcb;
+use as_raw_xcb_connection::AsRawXcbConnection;
 use ffi::*;
 use crate::{Keycode, ModMask, LayoutMask};
 use crate::{Context, Keymap, State};
@@ -52,9 +52,9 @@ impl From<i16> for LayoutMask {
 }
 
 #[inline]
-pub fn device(connection: &xcb::Connection) -> Result<i32, ()> {
+pub fn device(connection: &impl AsRawXcbConnection) -> Result<i32, ()> {
 	unsafe {
-		match xkb_x11_get_core_keyboard_device_id(connection.get_raw_conn() as *mut _) {
+		match xkb_x11_get_core_keyboard_device_id(connection.as_raw_xcb_connection() as *mut _) {
 			-1 => Err(()),
 			id => Ok(id)
 		}
@@ -62,17 +62,17 @@ pub fn device(connection: &xcb::Connection) -> Result<i32, ()> {
 }
 
 #[inline]
-pub fn keymap(connection: &xcb::Connection, device: i32, context: &Context, flags: compile::Flags) -> Result<Keymap, ()> {
+pub fn keymap(connection: &impl AsRawXcbConnection, device: i32, context: &Context, flags: compile::Flags) -> Result<Keymap, ()> {
 	unsafe {
-		xkb_x11_keymap_new_from_device(context.as_ptr(), connection.get_raw_conn() as *mut _, device, flags.bits())
+		xkb_x11_keymap_new_from_device(context.as_ptr(), connection.as_raw_xcb_connection() as *mut _, device, flags.bits())
 			.as_mut().map(|ptr| Keymap::from_ptr(ptr)).ok_or(())
 	}
 }
 
 #[inline]
-pub fn state(connection: &xcb::Connection, device: i32, keymap: &Keymap) -> Result<State, ()> {
+pub fn state(connection: &impl AsRawXcbConnection, device: i32, keymap: &Keymap) -> Result<State, ()> {
 	unsafe {
-		xkb_x11_state_new_from_device(keymap.as_ptr(), connection.get_raw_conn() as *mut _, device)
+		xkb_x11_state_new_from_device(keymap.as_ptr(), connection.as_raw_xcb_connection() as *mut _, device)
 			.as_mut().map(|ptr| State::from_ptr(ptr)).ok_or(())
 	}
 }


### PR DESCRIPTION
There is a new crate "as-raw-xcb-connection" which provides a trait that can be used to get a raw pointer to a libxcb xcb_connection_t. This trait allows this crate to work with arbitrary versions of the xcb crate and other crates wrapping libxcb (as long as they implement this trait).

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

This is a draft since I want to wait for version 1.0 of AsRawXcbConnection before merging. See https://github.com/psychon/as-raw-xcb-connection/issues/1

Also, I bet you will want to wait for a new release of the xcb crate containing https://github.com/rust-x-bindings/rust-xcb/pull/218 before this can go in. Otherwise, this commit would make the crate unusable.